### PR TITLE
[added] Guessed answer displays in the incorrect message

### DIFF
--- a/src/app/basic-math/basic-math.component.html
+++ b/src/app/basic-math/basic-math.component.html
@@ -26,7 +26,7 @@
             id="mathPrompt" 
             tabindex="-1"
             aria-live="assertive">
-            {{ isOnResult ? (answer!.isCorrect ? "Correct" : "Incorrect. The correct answer is " + answer!.answer) : 
+            {{ isOnResult ? (answer!.isCorrect ? "Correct" : "Incorrect. The correct answer is " + answer!.answer + ". You guessed " + currentAnswer + ".") : 
               question.num1 + ' ' + question.operatorName + ' ' + question.num2 + ' = ' }}
           </p>
           @if (!isOnResult) {


### PR DESCRIPTION
This pull request includes a small but important change to the `src/app/basic-math/basic-math.component.html` file. The change enhances the feedback provided to users by including their incorrect answer in the response message.

* [`src/app/basic-math/basic-math.component.html`](diffhunk://#diff-7e0e3842159d1722ae3b70a3d444f43d497daa4774f26ed9a76b02c7f4d71a9aL29-R29): Modified the feedback message to include the user's incorrect answer when the answer is incorrect.

![image](https://github.com/user-attachments/assets/9d3954fa-3550-4c4d-a458-98463ba6d245)
